### PR TITLE
Feat: Allow users to input their own fetch functions (for proxies)

### DIFF
--- a/.changeset/fifty-baboons-fry.md
+++ b/.changeset/fifty-baboons-fry.md
@@ -1,0 +1,5 @@
+---
+"kiai.js": minor
+---
+
+Add an option to include a fetchFunction for the client which changes the function RequestHandler uses to contact the API

--- a/packages/kiai.js/src/KiaiClient.ts
+++ b/packages/kiai.js/src/KiaiClient.ts
@@ -1,6 +1,8 @@
 import { Message, RateLimitError, VirtualMessage } from "@buape/kiai-api-types"
 import { RequestHandler } from "./RequestHandler"
 import * as handlers from "./handlers"
+import fetch from "node-fetch"
+import { RequestInfo, RequestInit, Response } from "node-fetch"
 
 export class KiaiClient {
 	apiKey: string
@@ -23,12 +25,12 @@ export class KiaiClient {
 	 * @param options.debug Whether to enable debug mode
 	 * @constructor
 	 */
-	constructor(apiKey: string, options?: { baseURL?: string; version: `v${number}`; debug?: boolean }) {
+	constructor(apiKey: string, options?: { baseURL?: string; version: `v${number}`; debug?: boolean; fetchFunction: ((url: URL | RequestInfo, init?: RequestInit | undefined) => Promise<Response>) }) {
 		this.apiKey = apiKey
 		this.version = options?.version || "v1"
 		this.baseURL = options?.baseURL || `https://api.kiaibot.com/${this.version}`
 		this.debug = options?.debug || false
-		this._requestHandler = new RequestHandler(this.baseURL, this.apiKey, this.debug)
+		this._requestHandler = new RequestHandler(this.baseURL, this.apiKey, this.debug, options?.fetchFunction ?? fetch)
 
 		this.blacklist = new handlers.Blacklist(this._requestHandler)
 		this.leveling = new handlers.Leveling(this._requestHandler)

--- a/packages/kiai.js/src/KiaiClient.ts
+++ b/packages/kiai.js/src/KiaiClient.ts
@@ -25,7 +25,7 @@ export class KiaiClient {
 	 * @param options.debug Whether to enable debug mode
 	 * @constructor
 	 */
-	constructor(apiKey: string, options?: { baseURL?: string; version: `v${number}`; debug?: boolean; fetchFunction: ((url: URL | RequestInfo, init?: RequestInit | undefined) => Promise<Response>) }) {
+	constructor(apiKey: string, options?: { baseURL?: string; version?: `v${number}`; debug?: boolean; fetchFunction: ((url: URL | RequestInfo, init?: RequestInit | undefined) => Promise<Response>) }) {
 		this.apiKey = apiKey
 		this.version = options?.version || "v1"
 		this.baseURL = options?.baseURL || `https://api.kiaibot.com/${this.version}`

--- a/packages/kiai.js/src/RequestHandler.ts
+++ b/packages/kiai.js/src/RequestHandler.ts
@@ -1,14 +1,17 @@
 import { RateLimitError as APIRateLimitError } from "@buape/kiai-api-types"
 import fetch from "node-fetch"
+import { RequestInfo, RequestInit, Response } from "node-fetch"
 import { RatelimitError, APIError } from "."
 export class RequestHandler {
 	baseURL: string
 	apiKey: string
 	debug: boolean
-	constructor(baseURL: string, apiKey: string, debug: boolean = false) {
+	fetchFunction: ((url: URL | RequestInfo, init?: RequestInit | undefined) => Promise<Response>)
+	constructor(baseURL: string, apiKey: string, debug: boolean = false, fetchFunction: ((url: URL | RequestInfo, init?: RequestInit | undefined) => Promise<Response>) = fetch) {
 		this.baseURL = baseURL
 		this.apiKey = apiKey
 		this.debug = debug
+		this.fetchFunction = fetchFunction
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -31,7 +34,7 @@ export class RequestHandler {
 		}
 		if (this.debug) console.debug(`Sending request to ${url}\nMethod:\n  ${options.method}\nParams:\n  ${JSON.stringify(query)}`)
 		try {
-			const res = await fetch(url, options)
+			const res = await this.fetchFunction(url, options)
 			if (res.status >= 200 && res.status < 300) {
 				const json = (await res.json())
 				if (this.debug) console.debug("Success: \n", json)


### PR DESCRIPTION
You can pass a function that works similarly to the node-fetch fetch function which will be used instead of the node-fetch function.