### PR TITLE
Fix cannot access BaseHandler before initialization

### DIFF
--- a/.changeset/swift-cherries-double.md
+++ b/.changeset/swift-cherries-double.md
@@ -1,0 +1,5 @@
+---
+"kiai.js": patch
+---
+
+Fix kiai.js to work in CJS by fixing an error

--- a/packages/kiai.js/src/handlers/BaseHandler.ts
+++ b/packages/kiai.js/src/handlers/BaseHandler.ts
@@ -1,0 +1,8 @@
+import { RequestHandler } from "../RequestHandler"
+
+export class BaseHandler {
+    public _handler: RequestHandler
+    constructor(handler: RequestHandler) {
+        this._handler = handler
+    }
+}

--- a/packages/kiai.js/src/handlers/index.ts
+++ b/packages/kiai.js/src/handlers/index.ts
@@ -1,14 +1,14 @@
 import { RequestHandler } from "../RequestHandler"
 
-export { Blacklist } from "./Blacklist"
-export { Leveling } from "./Leveling"
-export { Multipliers } from "./Multipliers"
-export { Rewards } from "./Rewards"
-export { Settings } from "./Settings"
-
 export class BaseHandler {
     public _handler: RequestHandler
     constructor(handler: RequestHandler) {
         this._handler = handler
     }
 }
+
+export { Blacklist } from "./Blacklist"
+export { Leveling } from "./Leveling"
+export { Multipliers } from "./Multipliers"
+export { Rewards } from "./Rewards"
+export { Settings } from "./Settings"

--- a/packages/kiai.js/src/handlers/index.ts
+++ b/packages/kiai.js/src/handlers/index.ts
@@ -1,12 +1,4 @@
-import { RequestHandler } from "../RequestHandler"
-
-export class BaseHandler {
-    public _handler: RequestHandler
-    constructor(handler: RequestHandler) {
-        this._handler = handler
-    }
-}
-
+export { BaseHandler } from "./BaseHandler"
 export { Blacklist } from "./Blacklist"
 export { Leveling } from "./Leveling"
 export { Multipliers } from "./Multipliers"


### PR DESCRIPTION
When running kiai.js in CJS (having manually converted the @buape/kiai-api-types to CJS by editing node_modules files, thus bypassing https://github.com/buape/kiai/issues/232), it throws the following error:

```
ReferenceError: Cannot access 'BaseHandler' before initialization
    at Object.<anonymous> (/Users/oirnoir/Documents/Projects/Bots/node_modules/kiai.js/dist/index.cjs:106:25)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:110:18)
```

Looking at node_modules/kiai.js/dist/index.cjs, there are a number of classes that extend BaseHandler, but the class declaration for BaseHandler itself is below all of them. This PR attempts to move the declaration in the compiled file up above all the classes that would require it, thus allowing the code to be run without issue.